### PR TITLE
"Canvas is already in use" bug fixed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 dist-ssr
 *.local
 wrangler.toml
+.idea

--- a/src/components/Debounce.mixin.ts
+++ b/src/components/Debounce.mixin.ts
@@ -9,7 +9,9 @@ export default {
     debounce(this: any, fn: Function, delay: number, uid: string) {
       if (typeof fn === 'function') {
         clearTimeout(this.debounceTimers[uid]);
-        this.debounceTimers[uid] = setTimeout(() => fn.bind(this)(), delay);
+        this.debounceTimers[uid] = setTimeout(async () => {
+          await fn.bind(this)()
+        }, delay);
       }
     }
   }

--- a/src/components/charts/Chart.vue
+++ b/src/components/charts/Chart.vue
@@ -39,7 +39,7 @@ export default defineComponent({
   watch: {
     async data() {
       if (!this.loading && !import.meta.env.SSR) {
-        this.createChart()
+        await this.createChart()
       }
     }
   },
@@ -53,9 +53,11 @@ export default defineComponent({
     // Create chart
     await this.createChart()
     // Update on resize
-    window.addEventListener('resize', () => {
-      this.debounce(this.createChart, 500, `chart-${this.instance?.id}`)
-    });
+    window.addEventListener('resize', this.onResize);
+  },
+
+  beforeUnmount() {
+    window.removeEventListener('resize', this.onResize);
   },
 
   methods: {
@@ -86,6 +88,9 @@ export default defineComponent({
       })
       // Finish loading
       this.loading = false
+    },
+    onResize() {
+      this.debounce(this.createChart, 500, `chart-${this.instance?.id}`)
     }
   }
 })


### PR DESCRIPTION
"Canvas is already in use" bug fixed by removing the old resize event-listener, which pointed to non-existing instances. Additionally, explicit "await" added to createChart() function calls for better execution and to provide better async stack traces